### PR TITLE
protobuf import를 위한 서브 모듈 설정 추가

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "appcha-protocol"]
+	path = appcha-protocol
+	url = https://github.com/DDD-6/appcha-protocol.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "appcha-protocol"]
-	path = appcha-protocol
-	url = https://github.com/DDD-6/appcha-protocol.git
+[submodule "appcha-protobuf"]
+	path = appcha-protobuf
+	url = https://github.com/DDD-6/appcha-protobuf.git
 	branch = main


### PR DESCRIPTION
### 개요
- gRPC protobuf를 submodule로 사용하기 위한 설정을 추가합니다.
https://github.com/DDD-6/appcha-protocol
- `.gitmodules` 설정에 main branch를 포함합니다. dev를 바라보게 되면 개발중에 dev에 변경사항이 생기면 사이드 이펙트가 발생할 수 있기 때문입니다.