### PR TITLE
Feed 상세 화면을 별도의 액티비티로 분리

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -37,6 +37,7 @@ object Dependencies {
     const val APPCOMPAT = "androidx.appcompat:appcompat:${Versions.APPCOMPAT}"
     const val MATERIAL = "com.google.android.material:material:${Versions.MATERIAL}"
     const val ACTIVITY_KTX = "androidx.activity:activity-ktx:${Versions.ACTIVITY_KTX}"
+    const val ACTIVITY_COMPOSE = "androidx.activity:activity-compose:${Versions.ACTIVITY_KTX}"
     const val FRAGMENT_KTX = "androidx.fragment:fragment-ktx:${Versions.FRAGMENT_KTX}"
     const val PREFERENCE_KTX = "androidx.preference:preference-ktx:${Versions.PREFERENCE_KTX}"
     const val STARTUP = "androidx.startup:startup-runtime:${Versions.STARTUP}"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,7 +7,7 @@ object Versions {
     const val CORE_KTX = "1.3.2"
     const val APPCOMPAT = "1.2.0"
     const val MATERIAL = "1.2.1"
-    const val ACTIVITY_KTX = "1.3.1"
+    const val ACTIVITY_KTX = "1.4.0-rc01"
     const val FRAGMENT_KTX = "1.3.6"
     const val PREFERENCE_KTX = "1.1.1"
     const val STARTUP = "1.1.0"

--- a/modules/app/src/main/AndroidManifest.xml
+++ b/modules/app/src/main/AndroidManifest.xml
@@ -45,6 +45,10 @@
             android:screenOrientation="portrait" />
 
         <activity
+            android:name=".ui.feed.detail.FeedDetailActivity"
+            android:screenOrientation="portrait" />
+
+        <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true">
             <intent-filter>
@@ -58,6 +62,7 @@
                     android:scheme="kakao${kakao_api_native_key}" />
             </intent-filter>
         </activity>
+
 
     </application>
 

--- a/modules/ui/build.gradle.kts
+++ b/modules/ui/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
     implementation(project(Module.DOMAIN))
     implementation(project(Module.CORE_ARCH))
 
+    implementation(Dependencies.ACTIVITY_COMPOSE)
+
     implementation(Dependencies.CORE_KTX)
     implementation(Dependencies.COMPOSE_UI)
     implementation(Dependencies.COMPOSE_TOOLING)

--- a/modules/ui/src/main/java/com/editor/appcha/ui/feed/FeedScreen.kt
+++ b/modules/ui/src/main/java/com/editor/appcha/ui/feed/FeedScreen.kt
@@ -28,6 +28,7 @@ import com.editor.appcha.ui.R
 import com.editor.appcha.ui.base.observe
 import com.editor.appcha.ui.component.NetworkImage
 import com.editor.appcha.ui.feed.FeedViewModel.Event
+import com.editor.appcha.ui.feed.detail.FeedDetailActivity
 import com.editor.appcha.ui.model.AppModel
 import com.editor.appcha.ui.model.FeedModel
 import com.editor.appcha.ui.theme.AppTheme
@@ -37,8 +38,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun FeedScreen(
     viewModel: FeedViewModel,
-    snackbarHostState: SnackbarHostState,
-    navigateToDetail: (feedId: String) -> Unit,
+    snackbarHostState: SnackbarHostState
 ) {
     val state: FeedViewModel.State by viewModel.state.collectAsState()
     val feeds = state.feeds
@@ -46,7 +46,7 @@ fun FeedScreen(
 
     viewModel.event.observe { event ->
         when (event) {
-            is Event.NavigateToDetail -> navigateToDetail(event.id)
+            is Event.NavigateToDetail -> FeedDetailActivity.launch(context, event.id)
             is Event.OpenMarket -> context.playStore(event.url)
         }
     }

--- a/modules/ui/src/main/java/com/editor/appcha/ui/feed/detail/FeedDetail.kt
+++ b/modules/ui/src/main/java/com/editor/appcha/ui/feed/detail/FeedDetail.kt
@@ -1,4 +1,4 @@
-package com.editor.appcha.ui.feed
+package com.editor.appcha.ui.feed.detail
 
 import androidx.compose.runtime.Composable
 import com.editor.appcha.ui.component.AppText

--- a/modules/ui/src/main/java/com/editor/appcha/ui/feed/detail/FeedDetailActivity.kt
+++ b/modules/ui/src/main/java/com/editor/appcha/ui/feed/detail/FeedDetailActivity.kt
@@ -1,9 +1,11 @@
 package com.editor.appcha.ui.feed.detail
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.editor.appcha.ui.R
 import com.editor.appcha.ui.base.BaseActivity
 import com.editor.appcha.ui.base.EmptyViewEvent
 import com.editor.appcha.ui.base.EmptyViewModel
@@ -29,6 +31,10 @@ class FeedDetailActivity : BaseActivity<EmptyViewModel, EmptyViewEvent>() {
         }
     }
 
+    override fun finish() {
+        super.finish()
+        overridePendingTransition(R.anim.push_pop_enter, R.anim.push_pop_exit)
+    }
 
     companion object {
         private const val KEY_FEED_ID = "KEY_FEED_ID"
@@ -37,6 +43,10 @@ class FeedDetailActivity : BaseActivity<EmptyViewModel, EmptyViewEvent>() {
             val intent = Intent(context, FeedDetailActivity::class.java)
                 .putExtra(KEY_FEED_ID, feedId)
             context.startActivity(intent)
+
+            if (context is Activity) {
+                context.overridePendingTransition(R.anim.push_enter, R.anim.push_exit)
+            }
         }
     }
 }

--- a/modules/ui/src/main/java/com/editor/appcha/ui/feed/detail/FeedDetailActivity.kt
+++ b/modules/ui/src/main/java/com/editor/appcha/ui/feed/detail/FeedDetailActivity.kt
@@ -1,0 +1,42 @@
+package com.editor.appcha.ui.feed.detail
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import com.editor.appcha.ui.base.BaseActivity
+import com.editor.appcha.ui.base.EmptyViewEvent
+import com.editor.appcha.ui.base.EmptyViewModel
+import com.editor.appcha.ui.theme.AppTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class FeedDetailActivity : BaseActivity<EmptyViewModel, EmptyViewEvent>() {
+
+    override val viewModel: EmptyViewModel = EmptyViewModel()
+
+    override fun handleEvent(event: EmptyViewEvent) {
+        TODO("Not yet implemented")
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            AppTheme {
+                FeedDetail()
+            }
+        }
+    }
+
+
+    companion object {
+        private const val KEY_FEED_ID = "KEY_FEED_ID"
+
+        fun launch(context: Context, feedId: String) {
+            val intent = Intent(context, FeedDetailActivity::class.java)
+                .putExtra(KEY_FEED_ID, feedId)
+            context.startActivity(intent)
+        }
+    }
+}

--- a/modules/ui/src/main/java/com/editor/appcha/ui/home/Home.kt
+++ b/modules/ui/src/main/java/com/editor/appcha/ui/home/Home.kt
@@ -156,8 +156,7 @@ private fun HomeGraph(
             val viewModel: FeedViewModel = hiltViewModel()
             FeedScreen(
                 viewModel = viewModel,
-                snackbarHostState = snackbarHostState,
-                navigateToDetail = {  /* TODO: NavigateToDetail */ }
+                snackbarHostState = snackbarHostState
             )
         }
 

--- a/modules/ui/src/main/java/com/editor/appcha/ui/home/Home.kt
+++ b/modules/ui/src/main/java/com/editor/appcha/ui/home/Home.kt
@@ -29,10 +29,8 @@ import androidx.navigation.navArgument
 import com.editor.appcha.ui.community.Community
 import com.editor.appcha.ui.community.CommunityWrite
 import com.editor.appcha.ui.component.AppText
-import com.editor.appcha.ui.feed.FeedDetail
 import com.editor.appcha.ui.feed.FeedScreen
 import com.editor.appcha.ui.feed.FeedViewModel
-import com.editor.appcha.ui.home.HomeRoute.Feed.FEED_ID_KEY
 import com.editor.appcha.ui.home.HomeRoute.Profile.PROFILE_ID_KEY
 import com.editor.appcha.ui.profile.Profile
 import com.editor.appcha.ui.theme.AppTheme
@@ -161,13 +159,6 @@ private fun HomeGraph(
                 snackbarHostState = snackbarHostState,
                 navigateToDetail = {  /* TODO: NavigateToDetail */ }
             )
-        }
-
-        composable(
-            route = "${HomeRoute.Feed.route}/$FEED_ID_KEY",
-            arguments = listOf(navArgument(FEED_ID_KEY) { type = NavType.IntType })
-        ) {
-            FeedDetail()
         }
 
         composable(HomeRoute.Community.route) {

--- a/modules/ui/src/main/java/com/editor/appcha/ui/home/HomeRoute.kt
+++ b/modules/ui/src/main/java/com/editor/appcha/ui/home/HomeRoute.kt
@@ -2,9 +2,7 @@ package com.editor.appcha.ui.home
 
 sealed class HomeRoute(val route: String) {
 
-    object Feed : HomeRoute("feed") {
-        const val FEED_ID_KEY = "feedId"
-    }
+    object Feed : HomeRoute("feed")
 
     object Community : HomeRoute("community")
 

--- a/modules/ui/src/main/res/anim/push_pop_enter.xml
+++ b/modules/ui/src/main/res/anim/push_pop_enter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="170"
+        android:fromXDelta="-100%"
+        android:toXDelta="0%" />
+</set>
+

--- a/modules/ui/src/main/res/anim/push_pop_exit.xml
+++ b/modules/ui/src/main/res/anim/push_pop_exit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="170"
+        android:fromXDelta="0%"
+        android:toXDelta="100%" />
+</set>
+


### PR DESCRIPTION
## 개요
- 기존 Navigation에 포함되어 있는 FeedDetail 화면을 별도의 액티비티로 분리합니다.
- 분리하는 이유로는 WindowInsets을 사용하면서 네비게이션을 유지하기게 되면 visibility 상태에 따라 UI가 뚝뚝 끊기는 현상이 발생하고 있어서 자연스러운 전환 애니메이션을 위해서 입니다.

## 작업 내용
- FeedDetailActivtiy 추가
- Route에서 FeedDetail정보 삭제